### PR TITLE
Add letter prefixes to options

### DIFF
--- a/main.js
+++ b/main.js
@@ -1526,7 +1526,9 @@ document.addEventListener("DOMContentLoaded", () => {
       input.name = "q" + q.num;
       input.value = opt.value;
       label.appendChild(input);
-      label.appendChild(document.createTextNode(" " + opt.text));
+      label.appendChild(
+        document.createTextNode(" " + opt.value + ") " + opt.text)
+      );
       fieldset.appendChild(label);
       fieldset.appendChild(document.createElement("br"));
     });


### PR DESCRIPTION
## Summary
- prefix each question's options with their letter (a/b/c)

## Testing
- `node --check main.js`

------
https://chatgpt.com/codex/tasks/task_e_684c9b5679b8832897b6ec53661c8601