### PR TITLE
Add horizontal chart for factor scores

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,6 +100,11 @@
         <button type="submit">Enviar</button>
     </form>
 
+    <div class="chart-wrapper">
+        <canvas id="results-chart"></canvas>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -3800,4 +3800,50 @@ document.getElementById('survey-form').addEventListener('submit', evt => {
   if (dQ3) dQ3.textContent = decQ3;
   const dQ4 = document.getElementById('decat-q4');
   if (dQ4) dQ4.textContent = decQ4;
+
+  const labels = [
+    'A Soliloquia',
+    'B Baja Cap.esc.',
+    'C Debilidad Yo',
+    'E Sumisión',
+    'F Retraido',
+    'G Superego debil',
+    'H Timidez',
+    'I Severidad',
+    'L Confianza',
+    'M Objetividad',
+    'N Ingenuidad',
+    'O Adec. Serena',
+    'Q1 Conservadurismo',
+    'Q2 Dep. Grupal',
+    'Q3 Indiferencia',
+    'Q4 Tranquilidad'
+  ];
+  const data = [
+    decA, decB, decC, decE, decF, decG, decH, decI,
+    decL, decM, decN, decO, decQ1, decQ2, decQ3, decQ4
+  ];
+  if (!window.resultsChart) {
+    const ctx = document.getElementById('results-chart').getContext('2d');
+    window.resultsChart = new Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels: labels,
+        datasets: [{
+          label: 'Decat',
+          data: data,
+          backgroundColor: 'rgba(54, 162, 235, 0.6)'
+        }]
+      },
+      options: {
+        indexAxis: 'y',
+        scales: {
+          x: { beginAtZero: true, max: 10 }
+        }
+      }
+    });
+  } else {
+    window.resultsChart.data.datasets[0].data = data;
+    window.resultsChart.update();
+  }
 });

--- a/style.css
+++ b/style.css
@@ -63,3 +63,8 @@ button[type="submit"]:hover {
     padding: 5px;
     text-align: center;
 }
+
+.chart-wrapper {
+    max-width: 600px;
+    margin: 40px auto;
+}


### PR DESCRIPTION
## Summary
- add chart element for results
- include Chart.js and styles
- draw horizontal bar chart with factor results

## Testing
- `curl -I https://cdn.jsdelivr.net/npm/chart.js | head`

------
https://chatgpt.com/codex/tasks/task_e_684e4197c57083288ea26e2685bf52d0