### PR TITLE
Add personality profile line chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,6 +104,11 @@
         <canvas id="results-chart"></canvas>
     </div>
 
+    <div class="chart-wrapper">
+        <h2>Perfil de personalidad</h2>
+        <canvas id="perfil-chart"></canvas>
+    </div>
+
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2"></script>
     <script src="main.js"></script>

--- a/main.js
+++ b/main.js
@@ -3854,4 +3854,36 @@ document.getElementById('survey-form').addEventListener('submit', evt => {
     window.resultsChart.data.datasets[0].data = data;
     window.resultsChart.update();
   }
+
+  const perfilData = [
+    pbA, pbB, pbC, pbE, pbF, pbG, pbH, pbI,
+    pbL, pbM, pbN, pbO, pbQ1, pbQ2, pbQ3, pbQ4
+  ];
+  if (!window.perfilChart) {
+    const perfilCtx = document.getElementById('perfil-chart').getContext('2d');
+    window.perfilChart = new Chart(perfilCtx, {
+      type: 'line',
+      data: {
+        labels: ['A','B','C','E','F','G','H','I','L','M','N','O','Q1','Q2','Q3','Q4'],
+        datasets: [{
+          label: 'Factores de personalidad',
+          data: perfilData,
+          borderColor: 'red',
+          backgroundColor: 'blue',
+          pointBackgroundColor: 'blue',
+          fill: false,
+          tension: 0.3,
+          pointRadius: 6,
+          pointHoverRadius: 8
+        }]
+      },
+      options: {
+        scales: { y: { beginAtZero: true, max: 20 } },
+        plugins: { legend: { display: false } }
+      }
+    });
+  } else {
+    window.perfilChart.data.datasets[0].data = perfilData;
+    window.perfilChart.update();
+  }
 });


### PR DESCRIPTION
## Summary
- show a second chart for `Perfil de personalidad`
- plot the PB factor results using a line chart

## Testing
- `node -e "console.log('no tests')"`

------
https://chatgpt.com/codex/tasks/task_e_684e467cbdbc8328ba96760aeed36863