### PR TITLE
Preselect A options and toggle colors

### DIFF
--- a/main.js
+++ b/main.js
@@ -3373,12 +3373,25 @@ document.addEventListener("DOMContentLoaded", () => {
     const legend = document.createElement("legend");
     legend.textContent = q.num + ". " + q.text;
     fieldset.appendChild(legend);
+    const updateColors = () => {
+      fieldset.querySelectorAll('label').forEach(l => {
+        l.classList.remove('user-selected');
+        l.classList.remove('default-selected');
+      });
+      const checked = fieldset.querySelector('input:checked');
+      if (checked) checked.parentElement.classList.add('user-selected');
+    };
     q.options.forEach(opt => {
       const label = document.createElement("label");
       const input = document.createElement("input");
       input.type = "radio";
       input.name = "q" + q.num;
       input.value = opt.value;
+      if (opt.value === 'a') {
+        input.checked = true;
+        label.classList.add('default-selected');
+      }
+      input.addEventListener('click', updateColors);
       label.appendChild(input);
       label.appendChild(
         document.createTextNode(" " + opt.value + ") " + opt.text)

--- a/style.css
+++ b/style.css
@@ -30,6 +30,14 @@ fieldset.personal-data label {
     margin-bottom: 1.5em;
 }
 
+label.default-selected {
+    color: red;
+}
+
+label.user-selected {
+    color: blue;
+}
+
 #questions-container {
     display: grid;
     grid-template-columns: 1fr 1fr;


### PR DESCRIPTION
## Summary
- default A answers are preselected in red
- change selected option to blue when clicked

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684e4b37a8dc8328b073e2a8e9f72aaa