### PR TITLE
Add tables and centered perfil bar chart

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,8 +108,55 @@
     </div>
 
     <div class="chart-wrapper">
-        <h2>Perfil de personalidad</h2>
-        <canvas id="perfil-chart"></canvas>
+        <h2 style="text-align:center">PERFIL DEL CUESTIONARIO 16 PF</h2>
+        <div class="tabla-container">
+            <table>
+                <tr>
+                    <th>Factor</th>
+                    <th>PB</th>
+                    <th>Decat</th>
+                    <th>Baja Puntuación</th>
+                </tr>
+                <tr><td>A</td><td id="perfil-pb-a"></td><td id="perfil-decat-a"></td><td>Soliloquia</td></tr>
+                <tr><td>B</td><td id="perfil-pb-b"></td><td id="perfil-decat-b"></td><td>Baja Cap.esc.</td></tr>
+                <tr><td>C</td><td id="perfil-pb-c"></td><td id="perfil-decat-c"></td><td>Debilidad Yo</td></tr>
+                <tr><td>E</td><td id="perfil-pb-e"></td><td id="perfil-decat-e"></td><td>Sumisión</td></tr>
+                <tr><td>F</td><td id="perfil-pb-f"></td><td id="perfil-decat-f"></td><td>Retraido</td></tr>
+                <tr><td>G</td><td id="perfil-pb-g"></td><td id="perfil-decat-g"></td><td>Superego debil</td></tr>
+                <tr><td>H</td><td id="perfil-pb-h"></td><td id="perfil-decat-h"></td><td>Timidez</td></tr>
+                <tr><td>I</td><td id="perfil-pb-i"></td><td id="perfil-decat-i"></td><td>Severidad</td></tr>
+                <tr><td>L</td><td id="perfil-pb-l"></td><td id="perfil-decat-l"></td><td>Confianza</td></tr>
+                <tr><td>M</td><td id="perfil-pb-m"></td><td id="perfil-decat-m"></td><td>Objetividad</td></tr>
+                <tr><td>N</td><td id="perfil-pb-n"></td><td id="perfil-decat-n"></td><td>Ingenuidad</td></tr>
+                <tr><td>O</td><td id="perfil-pb-o"></td><td id="perfil-decat-o"></td><td>Adec. Serena</td></tr>
+                <tr><td>Q1</td><td id="perfil-pb-q1"></td><td id="perfil-decat-q1"></td><td>Conservadurismo</td></tr>
+                <tr><td>Q2</td><td id="perfil-pb-q2"></td><td id="perfil-decat-q2"></td><td>Dep. Grupal</td></tr>
+                <tr><td>Q3</td><td id="perfil-pb-q3"></td><td id="perfil-decat-q3"></td><td>Indiferencia</td></tr>
+                <tr><td>Q4</td><td id="perfil-pb-q4"></td><td id="perfil-decat-q4"></td><td>Tranquilidad</td></tr>
+            </table>
+            <canvas id="perfil-chart"></canvas>
+            <table>
+                <tr>
+                    <th>Alta Puntuación</th>
+                </tr>
+                <tr><td>Sociabilidad</td></tr>
+                <tr><td>Alta Cap.esc.</td></tr>
+                <tr><td>Fuerza sup del Yo</td></tr>
+                <tr><td>Dominante</td></tr>
+                <tr><td>Impetuosidad</td></tr>
+                <tr><td>Superego fuerte</td></tr>
+                <tr><td>Audacia</td></tr>
+                <tr><td>Sensib. Emoc</td></tr>
+                <tr><td>Desconfianza</td></tr>
+                <tr><td>Subjetividad</td></tr>
+                <tr><td>Astucia</td></tr>
+                <tr><td>Propens. Culpabil.</td></tr>
+                <tr><td>Radicalismo</td></tr>
+                <tr><td>Autosuficiencia</td></tr>
+                <tr><td>Control</td></tr>
+                <tr><td>Tensión</td></tr>
+            </table>
+        </div>
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>

--- a/main.js
+++ b/main.js
@@ -3935,6 +3935,13 @@ document.getElementById('survey-form').addEventListener('submit', evt => {
     decA, decB, decC, decE, decF, decG, decH, decI,
     decL, decM, decN, decO, decQ1, decQ2, decQ3, decQ4
   ];
+
+  factorLetters.forEach((f, idx) => {
+    const pbCell = document.getElementById(`perfil-pb-${f.toLowerCase()}`);
+    if (pbCell) pbCell.textContent = pbData[idx];
+    const decCell = document.getElementById(`perfil-decat-${f.toLowerCase()}`);
+    if (decCell) decCell.textContent = decatData[idx];
+  });
   Chart.register(ChartDataLabels);
   if (!window.resultsChart) {
     const ctx = document.getElementById('results-chart').getContext('2d');
@@ -3988,25 +3995,26 @@ document.getElementById('survey-form').addEventListener('submit', evt => {
     pbL, pbM, pbN, pbO, pbQ1, pbQ2, pbQ3, pbQ4
   ];
   if (!window.perfilChart) {
-    const perfilCtx = document.getElementById('perfil-chart').getContext('2d');
+    const perfilCanvas = document.getElementById('perfil-chart');
+    if (perfilCanvas) perfilCanvas.height = chartHeight;
+    const perfilCtx = perfilCanvas.getContext('2d');
     window.perfilChart = new Chart(perfilCtx, {
-      type: 'line',
+      type: 'bar',
       data: {
-        labels: ['A','B','C','E','F','G','H','I','L','M','N','O','Q1','Q2','Q3','Q4'],
+        labels: factorLetters,
         datasets: [{
-          label: 'Factores de personalidad',
+          label: 'PB',
           data: perfilData,
-          borderColor: 'red',
-          backgroundColor: 'blue',
-          pointBackgroundColor: 'blue',
-          fill: false,
-          tension: 0.3,
-          pointRadius: 6,
-          pointHoverRadius: 8
+          backgroundColor: 'rgba(54, 162, 235, 0.7)',
+          borderColor: 'rgba(54, 162, 235, 1)',
+          borderWidth: 1
         }]
       },
       options: {
-        scales: { y: { beginAtZero: true, max: 20 } },
+        indexAxis: 'y',
+        scales: {
+          x: { beginAtZero: true, max: 20 }
+        },
         plugins: { legend: { display: false } }
       }
     });

--- a/style.css
+++ b/style.css
@@ -103,3 +103,31 @@ button#generate-report:hover {
     max-width: 500px;
 }
 
+.tabla-container {
+    display: flex;
+    justify-content: space-between;
+    gap: 30px;
+    margin-bottom: 40px;
+}
+
+.tabla-container table {
+    border-collapse: collapse;
+    width: 48%;
+}
+
+.tabla-container th,
+.tabla-container td {
+    border: 1px solid #aaa;
+    padding: 8px;
+    text-align: center;
+}
+
+.tabla-container th {
+    background-color: #f2f2f2;
+}
+
+.tabla-container canvas {
+    flex: 1;
+    max-width: 100%;
+}
+


### PR DESCRIPTION
## Summary
- design new layout for the personality profile
- position a horizontal bar chart between the low/high score tables
- style the new layout
- populate tables dynamically and render chart as a bar graph

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684f5659b1888328a6077ab2058821c2