### PR TITLE
Align results chart to left

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,6 +104,7 @@
     <div class="chart-wrapper">
         <h2 style="text-align:center">PERFIL DEL CUESTIONARIO 16 PF</h2>
         <div class="tabla-container">
+            <canvas id="results-chart"></canvas>
             <table>
                 <tr>
                     <th>Factor</th>
@@ -128,7 +129,6 @@
                 <tr><td>Q3</td><td id="res-pb-q3"></td><td id="res-decat-q3"></td><td>Indiferencia</td></tr>
                 <tr><td>Q4</td><td id="res-pb-q4"></td><td id="res-decat-q4"></td><td>Tranquilidad</td></tr>
             </table>
-            <canvas id="results-chart"></canvas>
             <table>
                 <tr>
                     <th>Alta Puntuaci&oacute;n</th>


### PR DESCRIPTION
## Summary
- move results chart before tables to keep it left aligned

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f8512e5388328820a5a98acd80f44