### PR TITLE
Update layout for profile section

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,28 @@
         <div class="tabla-container">
             <table>
                 <tr>
+                    <th>Alta Puntuaci&oacute;n</th>
+                </tr>
+                <tr><td>Sociabilidad</td></tr>
+                <tr><td>Alta Cap.esc.</td></tr>
+                <tr><td>Fuerza sup del Yo</td></tr>
+                <tr><td>Dominante</td></tr>
+                <tr><td>Impetuosidad</td></tr>
+                <tr><td>Superego fuerte</td></tr>
+                <tr><td>Audacia</td></tr>
+                <tr><td>Sensib. Emoc</td></tr>
+                <tr><td>Desconfianza</td></tr>
+                <tr><td>Subjetividad</td></tr>
+                <tr><td>Astucia</td></tr>
+                <tr><td>Propens. Culpabil.</td></tr>
+                <tr><td>Radicalismo</td></tr>
+                <tr><td>Autosuficiencia</td></tr>
+                <tr><td>Control</td></tr>
+                <tr><td>Tensi&oacute;n</td></tr>
+            </table>
+            <canvas id="results-chart"></canvas>
+            <table>
+                <tr>
                     <th>Factor</th>
                     <th>PB</th>
                     <th>Decat</th>
@@ -127,28 +149,6 @@
                 <tr><td>Q2</td><td id="res-pb-q2"></td><td id="res-decat-q2"></td><td>Dep. Grupal</td></tr>
                 <tr><td>Q3</td><td id="res-pb-q3"></td><td id="res-decat-q3"></td><td>Indiferencia</td></tr>
                 <tr><td>Q4</td><td id="res-pb-q4"></td><td id="res-decat-q4"></td><td>Tranquilidad</td></tr>
-            </table>
-            <canvas id="results-chart"></canvas>
-            <table>
-                <tr>
-                    <th>Alta Puntuaci&oacute;n</th>
-                </tr>
-                <tr><td>Sociabilidad</td></tr>
-                <tr><td>Alta Cap.esc.</td></tr>
-                <tr><td>Fuerza sup del Yo</td></tr>
-                <tr><td>Dominante</td></tr>
-                <tr><td>Impetuosidad</td></tr>
-                <tr><td>Superego fuerte</td></tr>
-                <tr><td>Audacia</td></tr>
-                <tr><td>Sensib. Emoc</td></tr>
-                <tr><td>Desconfianza</td></tr>
-                <tr><td>Subjetividad</td></tr>
-                <tr><td>Astucia</td></tr>
-                <tr><td>Propens. Culpabil.</td></tr>
-                <tr><td>Radicalismo</td></tr>
-                <tr><td>Autosuficiencia</td></tr>
-                <tr><td>Control</td></tr>
-                <tr><td>Tensi&oacute;n</td></tr>
             </table>
         </div>
         

--- a/style.css
+++ b/style.css
@@ -88,7 +88,7 @@ button#generate-report:hover {
 }
 
 .chart-wrapper {
-    max-width: 600px;
+    max-width: 1000px;
     margin: 40px auto;
 }
 
@@ -106,13 +106,17 @@ button#generate-report:hover {
 .tabla-container {
     display: flex;
     justify-content: space-between;
-    gap: 30px;
+    gap: 20px;
     margin-bottom: 40px;
 }
 
 .tabla-container table {
     border-collapse: collapse;
-    width: 48%;
+    width: 30%;
+}
+
+.tabla-container canvas {
+    width: 40%;
 }
 
 .tabla-container th,


### PR DESCRIPTION
## Summary
- reorder the 16PF results tables to place high score items on the left
- widen the profile layout for better spacing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f8eeeecdc83289adf9e2b3a659f14