### PR TITLE
Improve layout for 16PF profile

### DIFF
--- a/style.css
+++ b/style.css
@@ -104,15 +104,20 @@ button#generate-report:hover {
 }
 
 .tabla-container {
-    display: flex;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
     gap: 30px;
     margin-bottom: 40px;
+    align-items: start;
 }
 
 .tabla-container table {
     border-collapse: collapse;
-    width: 48%;
+    width: 100%;
+}
+
+#results-chart {
+    max-width: 400px;
 }
 
 .tabla-container th,


### PR DESCRIPTION
## Summary
- fix grid layout so the PB/Decat table sticks to the left, the chart is centered and the high score table aligns to the right

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f91eeadc48328acdb37edbf85aa57